### PR TITLE
Allow clusters to be launched in regions other than us-east-1.

### DIFF
--- a/cassandralauncher/ec2.py
+++ b/cassandralauncher/ec2.py
@@ -60,7 +60,8 @@ def create_cluster(aws_access_key_id, aws_secret_access_key, reservation_size, i
 
     # Connect to EC2
     print 'Starting an EC2 cluster of type {0} with image {1}...'.format(instance_type, image)
-    conn = boto.connect_ec2(aws_access_key_id, aws_secret_access_key)
+    conn = boto.ec2.connect_to_region(placement[:-1], aws_access_key_id=aws_access_key_id,
+                                      aws_secret_access_key=aws_secret_access_key)
 
     # Ensure PEM key is created
     try:


### PR DESCRIPTION
Connect boto to the region specified by the placement argument. I wasn't able to launch in us-west-1 without changing the connect code.

Downside is that terminate code won't search all the regions and find this cluster.
